### PR TITLE
Use CAMERA_SOURCE environment variable to set source

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,6 +12,9 @@ else:
 # Raspberry Pi camera module (requires picamera package)
 # from camera_pi import Camera
 
+if os.environ.get('CAMERA_SOURCE'):
+    Camera.set_video_source(os.environ['CAMERA_SOURCE'])
+
 app = Flask(__name__)
 
 

--- a/camera_opencv.py
+++ b/camera_opencv.py
@@ -7,7 +7,10 @@ class Camera(BaseCamera):
 
     @staticmethod
     def set_video_source(source):
-        Camera.video_source = source
+        try:
+            Camera.video_source = int(source)
+        except ValueError:
+            Camera.video_source = source
 
     @staticmethod
     def frames():


### PR DESCRIPTION
For VideoCapture, convert source to an integer if not a string.

Signed-off-by: Edward Swarthout <ed.swarthout@gmail.com>